### PR TITLE
protocol: packp, Support filter capabilities when encoding UploadRequest

### DIFF
--- a/plumbing/protocol/packp/ulreq.go
+++ b/plumbing/protocol/packp/ulreq.go
@@ -17,7 +17,10 @@ type UploadRequest struct {
 	Wants        []plumbing.Hash
 	Shallows     []plumbing.Hash
 	Depth        Depth
+	Filter       Filter
 }
+
+type Filter string
 
 // Depth values stores the desired depth of the requested packfile: see
 // DepthCommit, DepthSince and DepthReference.
@@ -64,6 +67,7 @@ func NewUploadRequest() *UploadRequest {
 		Wants:        []plumbing.Hash{},
 		Shallows:     []plumbing.Hash{},
 		Depth:        DepthCommits(0),
+		Filter:       "",
 	}
 }
 

--- a/plumbing/protocol/packp/ulreq_encode.go
+++ b/plumbing/protocol/packp/ulreq_encode.go
@@ -132,6 +132,16 @@ func (e *ulReqEncoder) encodeDepth() stateFn {
 		return nil
 	}
 
+	return e.encodeFilter
+}
+
+func (e *ulReqEncoder) encodeFilter() stateFn {
+	if e.data.Filter != "" {
+		if err := e.pe.Encodef("filter %s\n", e.data.Filter); err != nil {
+			e.err = fmt.Errorf("encoding filter %s: %s", e.data.Filter, err)
+			return nil
+		}
+	}
 	return e.encodeFlush
 }
 


### PR DESCRIPTION
go-git doesn't support using the `filter` capability: https://git-scm.com/docs/protocol-capabilities#_filter
We need this to retrieve blob-less packfiles to populate GitDB (`filter=blob:none`).

This PR updates the UploadRequest to have a Filter field that will be encoded in the upload-pack request.